### PR TITLE
編集機能や年度、月を入れたらfilterするviewMoneyを作りました。

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 # MoneyList
 
-- [] create List
-- [] delete List
-- [] update List
-- [] viewmoney
+- [x] create List
+- [x] delete List
+- [x] update List
+- [x] viewmoney

--- a/src/MoneyList/editMoney/editMoney.resolvers.js
+++ b/src/MoneyList/editMoney/editMoney.resolvers.js
@@ -1,0 +1,43 @@
+import client from "../../client";
+
+export default {
+  Mutation: {
+    editMoney: async (
+      _,
+      { id, title, amount, date, year, month },
+      { loggedInUser }
+    ) => {
+      if (!loggedInUser) {
+        return {
+          ok: false,
+          error: "ログインしてください。",
+        };
+      }
+
+      const money = await client.moneyList.findUnique({
+        where: {
+          id,
+        },
+      });
+      if (!money) {
+        return {
+          ok: false,
+          error: "編集する対象がありません。",
+        };
+      }
+      await client.moneyList.update({
+        where: { id },
+        data: {
+          title,
+          amount,
+          date,
+          year,
+          month,
+        },
+      });
+      return {
+        ok: true,
+      };
+    },
+  },
+};

--- a/src/MoneyList/editMoney/editMoney.typeDefs.js
+++ b/src/MoneyList/editMoney/editMoney.typeDefs.js
@@ -1,0 +1,14 @@
+import { gql } from "apollo-server";
+
+export default gql`
+  type Mutation {
+    editMoney(
+      id: Int!
+      title: String
+      amount: Int
+      date: String
+      year: Int
+      month: Int
+    ): MutationResult!
+  }
+`;

--- a/src/MoneyList/viewMoney/viewMoney.resolvers.js
+++ b/src/MoneyList/viewMoney/viewMoney.resolvers.js
@@ -1,0 +1,14 @@
+import client from "../../client";
+
+export default {
+  Query: {
+    viewMoney: async (_, { year, month }, { loggedInUser }) =>
+      await client.moneyList.findMany({
+        where: {
+          userId: loggedInUser.id,
+          year,
+          month,
+        },
+      }),
+  },
+};

--- a/src/MoneyList/viewMoney/viewMoney.typeDefs.js
+++ b/src/MoneyList/viewMoney/viewMoney.typeDefs.js
@@ -1,0 +1,7 @@
+import { gql } from "apollo-server";
+
+export default gql`
+  type Query {
+    viewMoney(year: Int!, month: Int): [MoneyList!]!
+  }
+`;

--- a/src/User/user.utils.js
+++ b/src/User/user.utils.js
@@ -1,4 +1,3 @@
-import jsonwebtoken from "jsonwebtoken";
 import jwt from "jsonwebtoken";
 import client from "../client";
 


### PR DESCRIPTION
編集機能は削除と同じように処理いたしました。
viewMoneyはback-endではfilterしてfrontに送ることが出来ましたが実力が足りず、front-end段階でどのように活用すればいいかはまだ考えられません。
viewMoneyは月のみ入力してしまうと去年のデータと被ってるのではないかと思い年度は必修で月はoptionalにしました。
以上、back-endは終わりです。
# @ezdar2743
[add edit money list](https://github.com/ezdar2743/intern-server/pull/11/commits/8016735c7b28bf725103d31f7d7c26692032718f) からです！
# add
[6fbcfd1](https://github.com/ezdar2743/intern-server/commit/6fbcfd12dfd8f14b91fb4197b886040afd774a54)
mainとmergeしたものです！